### PR TITLE
lusipad/ClawHarness#7: V2 GitHub live end-to-end PR validation stdin rerun

### DIFF
--- a/.executor-artifacts/34a87604-6c44-4177-86b1-7676cb77f6cf--pr-feedback--9850839e/pr-feedback-result.json
+++ b/.executor-artifacts/34a87604-6c44-4177-86b1-7676cb77f6cf--pr-feedback--9850839e/pr-feedback-result.json
@@ -1,0 +1,29 @@
+{
+  "status": "completed",
+  "summary": "Verified branch refs/heads/ai/7-v2-github-live-end-to-end-pr-validation- at commit 8d8fcbb6627eb30a518a603c78cc2ac2605b93e1 already contains the documentation updates requested by the active PR feedback. README.md already separates the live-validated Windows stdin rerun path from the still-pending webhook path, restores webhook-driven GitHub issue-to-PR coverage to the remaining live-validation gaps, and README.zh-CN.md mirrors the same validation scope. No additional workspace edits were required in this resumed pass.",
+  "changed_files": [],
+  "checks": [
+    {
+      "name": "git diff --check",
+      "status": "passed"
+    },
+    {
+      "name": "python -m unittest discover -s tests -v",
+      "status": "passed",
+      "details": "121 tests"
+    },
+    {
+      "name": "python -m compileall ado_client codex_acp_runner github_client harness_runtime rocketchat_notifier run_store workflow_provider tests",
+      "status": "passed"
+    },
+    {
+      "name": "git status --short",
+      "status": "passed",
+      "details": "clean worktree"
+    }
+  ],
+  "follow_up": [
+    "Harness can post this verification summary to PR #8 and resolve the active review threads.",
+    "No new commit or push is required from this resumed pass."
+  ]
+}

--- a/.executor-artifacts/34a87604-6c44-4177-86b1-7676cb77f6cf--pr-feedback--e61b4a60/pr-feedback-result.json
+++ b/.executor-artifacts/34a87604-6c44-4177-86b1-7676cb77f6cf--pr-feedback--e61b4a60/pr-feedback-result.json
@@ -1,0 +1,30 @@
+{
+  "status": "completed",
+  "summary": "Verified that branch refs/heads/ai/7-v2-github-live-end-to-end-pr-validation- at commit 03e262b3418a139eaff9c51bb4839b5701655c54 already contains the documentation updates requested by the active PR feedback. README.md already splits the Windows GitHub stdin rerun validation from the still-pending webhook-driven GitHub path, restores GitHub issue-to-PR to the remaining live-validation gaps, and README.zh-CN.md mirrors the same validation scope. No additional tracked repository edits were required in this resumed pass.",
+  "changed_files": [],
+  "checks": [
+    {
+      "command": "git diff --check",
+      "status": "passed"
+    },
+    {
+      "command": "python -m unittest discover -s tests -v",
+      "status": "passed",
+      "details": "121 tests"
+    },
+    {
+      "command": "python -m compileall ado_client codex_acp_runner github_client harness_runtime rocketchat_notifier run_store workflow_provider tests",
+      "status": "passed"
+    },
+    {
+      "command": "git diff --check",
+      "status": "passed",
+      "details": "re-run after verification"
+    }
+  ],
+  "follow_up": [
+    "Harness can publish this completion summary on PR #8 and reply to the active review threads; no commit, push, or new PR is required because the existing branch head already contains the requested documentation updates.",
+    "If thread-specific wording is needed, cite that README.md already separates the live-validated Windows stdin rerun path from the webhook-pending GitHub path and that README.zh-CN.md now matches the same scope.",
+    "The only new worktree entry from this executor pass is the required untracked artifact at .executor-artifacts/34a87604-6c44-4177-86b1-7676cb77f6cf--pr-feedback--e61b4a60/pr-feedback-result.json."
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ ClawHarness is an autonomous task-to-PR execution harness for Azure DevOps and G
 - The local Docker stack is live-validated with:
   `openclaw-gateway`, `clawharness-bridge`, and `openclaw-bot-view`
 - The Windows self-hosted Azure agent issue has been live-debugged and fixed; the documented recovery path is now part of `deploy/README.md`
-- GitHub provider support is implemented and covered by local tests, but live GitHub webhook validation is still blocked because `GITHUB_TOKEN` is not configured
+- GitHub issue-to-PR on Windows is now live-validated for the harness stdin rerun path; live webhook validation for PR feedback and checks recovery still remains blocked until `GITHUB_TOKEN` is configured
 
 ## Recommended Today
 
 - Use Docker as the default deployment path
 - Use Azure DevOps if you want the fully live-validated provider path today
 - Turn on the optional `bot-view` profile if you want a browser dashboard for OpenClaw and ClawHarness runtime status
-- Treat GitHub as implemented-but-not-yet-live-validated until webhook delivery is exercised in a real repository
+- Treat the Windows GitHub issue-to-PR path as live-validated, but keep PR feedback and checks recovery scoped as implemented until webhook delivery is exercised in a real repository
 
 ## Current V2 Delivery
 
@@ -123,6 +123,6 @@ The current implementation is already live-validated on the Azure-based core loo
 
 The main remaining gaps that still need broader live validation are:
 
-- GitHub issue-to-PR and checks recovery in a real repository with live webhook delivery
+- GitHub PR feedback and checks recovery in a real repository with live webhook delivery
 - policy interaction in repositories with stricter protected-branch and review rules
 - broader Linux native and non-local deployment validation

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ ClawHarness is an autonomous task-to-PR execution harness for Azure DevOps and G
 - The local Docker stack is live-validated with:
   `openclaw-gateway`, `clawharness-bridge`, and `openclaw-bot-view`
 - The Windows self-hosted Azure agent issue has been live-debugged and fixed; the documented recovery path is now part of `deploy/README.md`
-- GitHub issue-to-PR on Windows is now live-validated for the harness stdin rerun path; live webhook validation for PR feedback and checks recovery still remains blocked until `GITHUB_TOKEN` is configured
+- GitHub issue-to-PR on Windows is now live-validated for the harness stdin rerun path
+- Live GitHub webhook validation for issue-to-PR, PR feedback, and checks recovery still remains blocked until `GITHUB_TOKEN` is configured
 
 ## Recommended Today
 
 - Use Docker as the default deployment path
 - Use Azure DevOps if you want the fully live-validated provider path today
 - Turn on the optional `bot-view` profile if you want a browser dashboard for OpenClaw and ClawHarness runtime status
-- Treat the Windows GitHub issue-to-PR path as live-validated, but keep PR feedback and checks recovery scoped as implemented until webhook delivery is exercised in a real repository
+- Treat the Windows GitHub issue-to-PR stdin rerun path as live-validated, but keep the webhook-delivered GitHub path scoped as pending broader validation in a real repository
 
 ## Current V2 Delivery
 
@@ -123,6 +124,6 @@ The current implementation is already live-validated on the Azure-based core loo
 
 The main remaining gaps that still need broader live validation are:
 
-- GitHub PR feedback and checks recovery in a real repository with live webhook delivery
+- GitHub issue-to-PR, PR feedback, and checks recovery in a real repository with live webhook delivery
 - policy interaction in repositories with stricter protected-branch and review rules
 - broader Linux native and non-local deployment validation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,14 +47,15 @@ ClawHarness 是一个面向 Azure DevOps 与 GitHub 仓库的自主化任务到 
 - 本地 Docker 栈已完成真实验证：
   `openclaw-gateway`、`clawharness-bridge`、`openclaw-bot-view`
 - Windows self-hosted Azure agent 的 PowerShell 环境问题已完成真实排障和修复，修复方式已写入 `deploy/README.md`
-- GitHub provider 的代码与本地测试已就绪，但真实 GitHub webhook 联调仍受 `GITHUB_TOKEN` 未配置阻塞
+- Windows 上的 GitHub issue -> PR 已通过 harness stdin rerun 路径完成真实验证
+- GitHub issue -> PR、PR feedback 与 checks recovery 的真实 webhook 联调仍受 `GITHUB_TOKEN` 未配置阻塞
 
 ## 当前推荐用法
 
 - 默认优先使用 Docker 部署
 - 如果你现在就要走真实闭环，优先选 Azure DevOps
 - 如果你想在浏览器里看 OpenClaw 和 ClawHarness 的运行状态，建议同时开启可选的 `bot-view` profile
-- GitHub 当前属于“代码与本地测试已完成，但真实 webhook 还没验”的状态，适合继续联调，不适合宣称已完成 live
+- Windows GitHub issue -> PR 的 stdin rerun 路径可以视为已完成 live 验证，但 webhook 驱动的 GitHub 链路仍应视为待在真实仓库中继续验证
 
 ## 当前 V2 交付能力
 
@@ -123,6 +124,6 @@ python -m harness_runtime.main --task-id <task-id> --repo-id <repo-id> [--provid
 
 当前仍需要补齐更广泛真实环境验证的部分主要是：
 
-- 真实 GitHub issue 到 PR、以及 checks 恢复链路的 live webhook 验证
+- 真实 GitHub issue 到 PR、PR feedback 与 checks 恢复链路的 live webhook 验证
 - 受保护分支和评审策略更严格的仓库策略联动
 - Linux 原生和非本机环境部署的更广覆盖验证


### PR DESCRIPTION
Automated change for `lusipad/ClawHarness#7`.

Updated README.md to mark the Windows GitHub issue-to-PR stdin rerun path as live-validated while keeping GitHub PR feedback and checks recovery scoped as still needing live webhook validation. Local checks remained green: git diff --check passed and python -m unittest discover -s tests -v passed (121/121).

Review summary:
Approved for verification. README.md is the only changed file, the diff is a small documentation-only update for issue #7, the existing PR description path already includes the executor validation summary, and the claimed local checks reproduced cleanly in this workspace.

Verification summary:
Workspace is ready for PR creation for lusipad/ClawHarness#7: the branch and remote match the task context, the worktree contains only a small documentation-only README.md diff, the wording is scoped to Windows GitHub issue-to-PR live validation while keeping PR feedback and checks recovery marked as pending live webhook validation, and the local verification gates reproduced cleanly.

Follow-up:
- Harness can reuse this summary as the short validation note in the generated PR body or task comment.
- Live GitHub webhook validation for PR feedback and checks recovery still remains to be exercised in a real repository with GITHUB_TOKEN configured.